### PR TITLE
Adding support for custom html in tooltips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rcsb/rcsb-saguaro",
-  "version": "2.5.12",
+  "version": "2.5.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rcsb/rcsb-saguaro",
-      "version": "2.5.12",
+      "version": "2.5.13",
       "license": "MIT",
       "dependencies": {
         "@d3fc/d3fc-sample": "^5.0.1",

--- a/src/RcsbBoard/RcsbTooltip/RcsbTooltipManager.ts
+++ b/src/RcsbBoard/RcsbTooltip/RcsbTooltipManager.ts
@@ -44,77 +44,61 @@ export class RcsbTooltipManager {
     }
 
     showTooltip(d: RcsbFvTrackDataElementInterface){
-        // create parent div
-        const tooltipParentDiv = document.createElement('div');
-        tooltipParentDiv.style.display = 'flex';
-        tooltipParentDiv.style.flexDirection = 'column';
-    
-        // create top div
-        const tooltipTopDiv = document.createElement('div');
+        if(d.tooltipCallback == undefined) {
+            this.tooltipDiv.textContent = "";
 
-        this.tooltipDiv.textContent = "";
-        //this.toolttipTopDiv.textContent = "";
+            let region: string = "Position: "+d.begin.toString();
+            if(typeof d.end === "number" && d.end!=d.begin) region += " - "+d.end.toString();
+            const spanRegion: HTMLSpanElement = document.createElement<"span">("span");
+            spanRegion.append(region);
 
-        let region: string = "Position: "+d.begin.toString();
-        if(typeof d.end === "number" && d.end!=d.begin) region += " - "+d.end.toString();
-        const spanRegion: HTMLSpanElement = document.createElement<"span">("span");
-        spanRegion.append(region);
+            if(typeof d.beginName === "string" && d.indexName != undefined){
+                spanRegion.append(RcsbTooltipManager.buildIndexNames(d.beginName,d.endName,d.indexName));
+            }
 
-        if(typeof d.beginName === "string" && d.indexName != undefined){
-            spanRegion.append(RcsbTooltipManager.buildIndexNames(d.beginName,d.endName,d.indexName));
-        }
+            if(typeof d.oriBegin === "number"){
+                let ori_region: string = d.oriBegin.toString();
+                if(typeof d.oriEnd === "number") ori_region += " - "+d.oriEnd.toString();
+                const spanOriRegion: HTMLSpanElement = document.createElement<"span">("span");
+                if(d.source != undefined)
+                    spanOriRegion.append(" | ["+d.source.replace("_"," ")+"] "+d.sourceId+": "+ori_region);
+                spanOriRegion.style.color = "#888888";
+                if( typeof d.oriBeginName === "string" && d.indexName!= undefined)
+                    spanOriRegion.append(RcsbTooltipManager.buildIndexNames(d.oriBeginName,d.oriEndName,d.indexName));
+                spanRegion.append(spanOriRegion);
+            }
 
-        if(typeof d.oriBegin === "number"){
-            let ori_region: string = d.oriBegin.toString();
-            if(typeof d.oriEnd === "number") ori_region += " - "+d.oriEnd.toString();
-            const spanOriRegion: HTMLSpanElement = document.createElement<"span">("span");
-            if(d.source != undefined)
-                spanOriRegion.append(" | ["+d.source.replace("_"," ")+"] "+d.sourceId+": "+ori_region);
-            spanOriRegion.style.color = "#888888";
-            if( typeof d.oriBeginName === "string" && d.indexName!= undefined)
-                spanOriRegion.append(RcsbTooltipManager.buildIndexNames(d.oriBeginName,d.oriEndName,d.indexName));
-            spanRegion.append(spanOriRegion);
-        }
+            let title:string | undefined = d.title;
+            if(typeof d.name === "string") title = d.name;
+            else if( typeof d.featureId === "string") title = d.featureId;
+            if(title != undefined )this.tooltipDiv.append(title);
+            if(typeof d.provenanceName === "string"){
+                const spanProvenance: HTMLSpanElement = document.createElement<"span">("span");
 
-        let title:string | undefined = d.title;
-        if(typeof d.name === "string") title = d.name;
-        else if( typeof d.featureId === "string") title = d.featureId;
-        if(title != undefined )this.tooltipDiv.append(title);
-        if(typeof d.provenanceName === "string"){
-            const spanProvenance: HTMLSpanElement = document.createElement<"span">("span");
-
-            const spanProvenanceString: HTMLSpanElement = document.createElement<"span">("span");
-            spanProvenanceString.append(d.provenanceName);
-            if(typeof d.provenanceColor === "string")
-                spanProvenanceString.style.color = d.provenanceColor;
-            else
-                spanProvenanceString.style.color = "#888888";
-            spanProvenance.append(" [",spanProvenanceString,"]");
-            spanProvenance.style.color = "#888888";
-            this.tooltipDiv.append(spanProvenance);
-            this.tooltipDiv.append( RcsbTooltipManager.bNode() );
-        }else if(title!=undefined){
-            this.tooltipDiv.append( RcsbTooltipManager.bNode() );
-        }
-        if(typeof d.value === "number"){
-            const valueRegion: HTMLSpanElement = document.createElement<"span">("span");
-            valueRegion.append(" value: "+d.value);
-            this.tooltipDiv.append(valueRegion);
-            this.tooltipDiv.append(RcsbTooltipManager.bNode());
-        }
+                const spanProvenanceString: HTMLSpanElement = document.createElement<"span">("span");
+                spanProvenanceString.append(d.provenanceName);
+                if(typeof d.provenanceColor === "string")
+                    spanProvenanceString.style.color = d.provenanceColor;
+                else
+                    spanProvenanceString.style.color = "#888888";
+                spanProvenance.append(" [",spanProvenanceString,"]");
+                spanProvenance.style.color = "#888888";
+                this.tooltipDiv.append(spanProvenance);
+                this.tooltipDiv.append( RcsbTooltipManager.bNode() );
+            }else if(title!=undefined){
+                this.tooltipDiv.append( RcsbTooltipManager.bNode() );
+            }
+            if(typeof d.value === "number"){
+                const valueRegion: HTMLSpanElement = document.createElement<"span">("span");
+                valueRegion.append(" value: "+d.value);
+                this.tooltipDiv.append(valueRegion);
+                this.tooltipDiv.append(RcsbTooltipManager.bNode());
+            }
         
-        //this.tooltipDiv.append(spanRegion);
-        tooltipTopDiv.append(spanRegion);
-        tooltipParentDiv.append(tooltipTopDiv);
-
-        // create bottom div
-        const tooltipBottomDiv = document.createElement('div');
-        if (d.customTooltipHtml) {
-            tooltipBottomDiv.innerHTML = d.customTooltipHtml;
-            tooltipParentDiv.append(tooltipBottomDiv);
+            this.tooltipDiv.append(spanRegion);
+        } else {
+            this.tooltipDiv.innerHTML = d.tooltipCallback(d);
         }
-    
-        this.tooltipDiv.append(tooltipParentDiv);
         
         computePosition(this.refDiv,this.tooltipDiv,{
             placement:'top-end',

--- a/src/RcsbBoard/RcsbTooltip/RcsbTooltipManager.ts
+++ b/src/RcsbBoard/RcsbTooltip/RcsbTooltipManager.ts
@@ -44,8 +44,16 @@ export class RcsbTooltipManager {
     }
 
     showTooltip(d: RcsbFvTrackDataElementInterface){
+        // create parent div
+        const tooltipParentDiv = document.createElement('div');
+        tooltipParentDiv.style.display = 'flex';
+        tooltipParentDiv.style.flexDirection = 'column';
+    
+        // create top div
+        const tooltipTopDiv = document.createElement('div');
 
         this.tooltipDiv.textContent = "";
+        //this.toolttipTopDiv.textContent = "";
 
         let region: string = "Position: "+d.begin.toString();
         if(typeof d.end === "number" && d.end!=d.begin) region += " - "+d.end.toString();
@@ -94,7 +102,20 @@ export class RcsbTooltipManager {
             this.tooltipDiv.append(valueRegion);
             this.tooltipDiv.append(RcsbTooltipManager.bNode());
         }
-        this.tooltipDiv.append(spanRegion);
+        
+        //this.tooltipDiv.append(spanRegion);
+        tooltipTopDiv.append(spanRegion);
+        tooltipParentDiv.append(tooltipTopDiv);
+
+        // create bottom div
+        const tooltipBottomDiv = document.createElement('div');
+        if (d.customTooltipHtml) {
+            tooltipBottomDiv.innerHTML = d.customTooltipHtml;
+            tooltipParentDiv.append(tooltipBottomDiv);
+        }
+    
+        this.tooltipDiv.append(tooltipParentDiv);
+        
         computePosition(this.refDiv,this.tooltipDiv,{
             placement:'top-end',
             middleware:[{

--- a/src/RcsbDataManager/RcsbDataManager.ts
+++ b/src/RcsbDataManager/RcsbDataManager.ts
@@ -72,6 +72,8 @@ export interface RcsbFvTrackDataElementInterface {
     rectEnd?: number;
     /**Callback when the annotation is clicked*/
     elementClickCallBack?:(x: RcsbFvTrackDataElementInterface, e?: MouseEvent)=>void;
+    /**Custom HTML for hover tooltip*/
+    customTooltipHtml?: string;
 }
 
 export interface RcsbFvColorGradient {

--- a/src/RcsbDataManager/RcsbDataManager.ts
+++ b/src/RcsbDataManager/RcsbDataManager.ts
@@ -73,7 +73,7 @@ export interface RcsbFvTrackDataElementInterface {
     /**Callback when the annotation is clicked*/
     elementClickCallBack?:(x: RcsbFvTrackDataElementInterface, e?: MouseEvent)=>void;
     /**Custom HTML for hover tooltip*/
-    customTooltipHtml?: string;
+    tooltipCallback?: (x: RcsbFvTrackDataElementInterface)=>string;
 }
 
 export interface RcsbFvColorGradient {


### PR DESCRIPTION
Hi! For our usecase, we occasionally need to place our html/formatting in tooltips. I've put together this PR, in a fork we're currently working with to accomplish this, and if it seems like it would be of broad interest, I'd be happy to make changes as necessary to make it part of the library :)

Right now, the functionality works by adding a new parent flex div with flex direction column, and the new user provided html is added to a child div beneath the normal div.

Some alternatives that might make more sense:
- have an either or situation: either the user provided HTML fully overrides the default tooltip, or if there is no custom user tooltip, we use the default. We don't stack them vertically
- only add a parent div and flex-row if there is a custom tooltip added by the user (I think I definitely need to make this change)