### PR TITLE
Allow reference to HTMLElement in constructor.

### DIFF
--- a/src/RcsbFv/RcsbFv.tsx
+++ b/src/RcsbFv/RcsbFv.tsx
@@ -33,7 +33,7 @@ export interface RcsbFvInterface <
     /**Board global configuration*/
     readonly boardConfigData: RcsbFvBoardConfigInterface;
     /**DOM element Id where the PFV will be rendered*/
-    readonly elementId: string;
+    readonly elementId: string | HTMLElement;
 }
 
 /**
@@ -51,7 +51,7 @@ export class RcsbFv<
     /**Global board configuration*/
     private boardConfigData: RcsbFvBoardConfigInterface;
     /**DOM elemnt id where the board will be displayed*/
-    private readonly elementId: string;
+    private readonly elementId: string | HTMLElement;
     private readonly node: HTMLElement;
 
     /**Flag indicating that the React component has been mounted*/
@@ -75,7 +75,9 @@ export class RcsbFv<
     constructor(props: RcsbFvInterface<P,S,R,M>){
         this.boardConfigData = props.boardConfigData;
         this.elementId = props.elementId;
-        const node = document.getElementById(this.elementId);
+        const node = typeof this.elementId == "string"
+            ? document.getElementById(this.elementId)
+            : this.elementId;
         if(!node)
             throw new Error(`HTML element ${this.elementId} not found`)
         this.node = node;

--- a/src/RcsbFvExamples/CompositeTrack.ts
+++ b/src/RcsbFvExamples/CompositeTrack.ts
@@ -89,7 +89,13 @@ const sequenceConfigData: RcsbFvRowConfigInterface[] = [
         ]
     }];
 
-const fv = new RcsbFv({elementId:"pfv", boardConfigData, rowConfigData: [...sequenceConfigData, ...rowConfigData]});
+const element = document.getElementById("pfv");
+
+if (element == null){
+    throw "Unable to locate element";
+}
+
+const fv = new RcsbFv({elementId:element, boardConfigData, rowConfigData: [...sequenceConfigData, ...rowConfigData]});
 fv.then(()=>{
     console.log("Ready viewer");
 });


### PR DESCRIPTION
In some applications we may not have an id assigned to the parent element for the RcsbFv display,
so it's useful to be able to directly specify this as an HTMLElement.

Expands the constructor to support both elementId and a direct element reference.
I opted to leave this as a single parameter in order to reduce complexity, 
but would be happy to refactor if you believe this improves the interface.